### PR TITLE
Update get-easylist.sh

### DIFF
--- a/get-easylist.sh
+++ b/get-easylist.sh
@@ -28,7 +28,7 @@ fi
 
 get_squid_build_flag() { 
 	# $1: Build flag used during compile
-	squid -v | tr " " "\n" | grep -- "$1" | tail -n1 | cut -f2 -d '=' | sed "s/'//g"
+	$SQUID_BIN -v | tr " " "\n" | grep -- "$1" | tail -n1 | cut -f2 -d '=' | sed "s/'//g"
 }
 
 get_squid_conf_value() { 


### PR DESCRIPTION
Ubuntu 14.04 and Debian "Jessie" 8 have the option to install squid3 instead of squid. Line 31 errors for those systems, as it's dependent on "squid". By replacing it with the variable $SQUID_BIN it uses whatever version of squid is found on the system.
